### PR TITLE
AWS Congito Identity Provider is now GA

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These libraries integrate Amazon CloudWatch Logs with popular .NET logging libra
 [![nuget](https://img.shields.io/nuget/v/Amazon.Extensions.CognitoAuthentication.svg) ![downloads](https://img.shields.io/nuget/dt/Amazon.Extensions.CognitoAuthentication.svg)](https://www.nuget.org/packages/Amazon.Extensions.CognitoAuthentication/)  
 The Amazon Cognito Extension Library simplifies the authentication process of Amazon Cognito User Pools for .NET developers.  It allows you to use various authentication methods for Amazon Cognito User Pools with only a few short method calls, along with making the process intuitive.
 
-[ASP.NET Core Identity Provider for Amazon Cognito - Developer Preview](https://github.com/aws/aws-aspnet-cognito-identity-provider)  
+[ASP.NET Core Identity Provider for Amazon Cognito](https://github.com/aws/aws-aspnet-cognito-identity-provider)  
 [![nuget](https://img.shields.io/nuget/v/Amazon.AspNetCore.Identity.Cognito.svg) ![downloads](https://img.shields.io/nuget/dt/Amazon.AspNetCore.Identity.Cognito.svg)](https://www.nuget.org/packages/Amazon.AspNetCore.Identity.Cognito/)  
 ASP.NET Core Identity Provider for Amazon Cognito simplifies using Amazon Cognito as a membership storage solution for building ASP.NET Core web applications using ASP.NET Core Identity.
 


### PR DESCRIPTION
*Description of changes:*

Removing developer preview tag for cognito identity provider.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
