### PR TITLE
Temporary fix to the AWS.NET Developer Guide URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Amazon Web Services offers Amazon Machine Images (AMI) with .NET Core on Amazon 
 This repository holds Dockerfiles of official AWS CodeBuild curated Docker images. Please refer to the [AWS CodeBuild User Guide](https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref.html) for list of environments supported by AWS CodeBuild.
 
 ## Documentation
-[AWS .NET Developer Guide](https://docs.aws.amazon.com/sdk-for-net/latest/developer-guide)  
+[AWS .NET Developer Guide](https://docs.aws.amazon.com/sdk-for-net/latest/developer-guide/)  
 The AWS SDK for .NET Developer Guide describes how to implement applications for AWS using the AWS SDK for .NET
 
 [AWS SDK for .NET V3 API Reference](https://docs.aws.amazon.com/sdkfornet/v3/apidocs/Index.html)  


### PR DESCRIPTION
The target server for the the AWS.NET Developer Guide is requiring a trailing slash to resolve the URL. This is a temporary fix until the docs team updates the platform to resolve URLs with/without the trailing slash.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
