### PR TITLE
chore: switch DynamoDb Distributed Cache link from awslabs to aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ AWS X-Ray helps developers analyze and debug distributed applications. With X-Ra
 [![nuget](https://img.shields.io/nuget/v/Amazon.Extensions.S3.Encryption.svg) ![downloads](https://img.shields.io/nuget/dt/Amazon.Extensions.S3.Encryption.svg)](https://www.nuget.org/packages/Amazon.Extensions.S3.Encryption/)  
 Amazon S3 Encryption Client for .NET is a client-side encryption library designed to make it easy for everyone to encrypt and decrypt data using industry standards and best practices. It enables you to focus on the core functionality of your application, rather than on how to best encrypt and decrypt your data.
 
-[AWS .NET Distributed Cache Provider](https://github.com/awslabs/aws-dotnet-distributed-cache-provider)  
+[AWS .NET Distributed Cache Provider](https://github.com/aws/aws-dotnet-distributed-cache-provider)  
 [![nuget](https://img.shields.io/nuget/v/AWS.AspNetCore.DistributedCacheProvider.svg) ![downloads](https://img.shields.io/nuget/dt/AWS.AspNetCore.DistributedCacheProvider.svg)](https://www.nuget.org/packages/AWS.AspNetCore.DistributedCacheProvider/)  
 The AWS .NET Distributed Cache Provider provides an implementation of the ASP.NET Core interface [IDistributedCache](https://docs.microsoft.com/en-us/aspnet/core/performance/caching/distributed) backed by Amazon DynamoDB. A common use of an `IDistributedCache` implementation is to store ephemeral, non-critical [session state](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/app-state?#session-state) data in ASP.NET Core applications.
 


### PR DESCRIPTION
*Description of changes:*
Switch DynamoDb Distributed Cache link from awslabs to aws

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
